### PR TITLE
Bump cython version from 0.23 to 0.28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 
 install:
 - pip install cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cymem>=1.30,<1.31
-cython >= 0.23
+cython >= 0.28
 pytest


### PR DESCRIPTION
This diff fixes preshed to work with Python 3.7:

  - Cython is bumped from minor version 0.23 to 0.28
  - "3.7-dev" is added to the travis testing environments.

Closes #15