### PR TITLE
bugfix: counter.iter with map_get

### DIFF
--- a/preshed/about.py
+++ b/preshed/about.py
@@ -1,5 +1,5 @@
 __title__ = "preshed"
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __summary__ = "Cython hash table that trusts the keys are pre-hashed"
 __uri__ = "https://github.com/explosion/preshed"
 __author__ = "Matthew Honnibal"

--- a/preshed/counter.pxd
+++ b/preshed/counter.pxd
@@ -3,7 +3,7 @@ from libc.stdint cimport int64_t
 from cymem.cymem cimport Pool
 
 from .maps cimport MapStruct
-from .maps cimport map_init, map_get, map_set
+from .maps cimport map_init, map_get, map_set, map_iter
 from .maps cimport key_t
 
 

--- a/preshed/counter.pyx
+++ b/preshed/counter.pyx
@@ -24,8 +24,8 @@ cdef class PreshCounter:
     def __iter__(self):
         cdef int i
         for i in range(self.c_map.length):
-            if self.c_map.cells[i].key != 0:
-                yield (self.c_map.cells[i].key, <count_t>self.c_map.cells[i].value)
+            if i != 0:
+                yield (i, <count_t>map_get(self.c_map, i))
 
     def __getitem__(self, key_t key):
         return <count_t>map_get(self.c_map, key)

--- a/preshed/counter.pyx
+++ b/preshed/counter.pyx
@@ -22,11 +22,11 @@ cdef class PreshCounter:
         return self.c_map.length
 
     def __iter__(self):
-        cdef int i
-        for i in range(self.c_map.length):
-            key = self.c_map.cells[i].key
-            if key != 0:
-                yield (key, <count_t>map_get(self.c_map, key))
+        cdef int i = 0
+        cdef key_t key
+        cdef void* value
+        while map_iter(self.c_map, &i, &key, &value):
+            yield key, <size_t>value
 
     def __getitem__(self, key_t key):
         return <count_t>map_get(self.c_map, key)

--- a/preshed/counter.pyx
+++ b/preshed/counter.pyx
@@ -24,8 +24,9 @@ cdef class PreshCounter:
     def __iter__(self):
         cdef int i
         for i in range(self.c_map.length):
-            if i != 0:
-                yield (i, <count_t>map_get(self.c_map, i))
+            key = self.c_map.cells[i].key
+            if key != 0:
+                yield (key, <count_t>map_get(self.c_map, key))
 
     def __getitem__(self, key_t key):
         return <count_t>map_get(self.c_map, key)


### PR DESCRIPTION
Looking into spaCy issue https://github.com/explosion/spaCy/issues/3869, I found that the `counter.c_map.cells` sometimes behave inconsistently, not reflecting the actual underlying state of the counter. Changing the `__iter__` function to `map_iter` instead, fixed the issue.
