### PR TITLE
Add bloom filter class

### DIFF
--- a/preshed/bloom.pxd
+++ b/preshed/bloom.pxd
@@ -1,4 +1,4 @@
-from libc.stdint cimport uint32_t, uint64_t
+from libc.stdint cimport uint64_t
 from cymem.cymem cimport Pool
 
 ctypedef uint64_t key_t
@@ -17,7 +17,7 @@ cdef class BloomFilter:
 
 cdef void bloom_init(Pool mem, BloomStruct* bloom, key_t hcount, key_t length)
 
-cdef void bloom_add(BloomStruct* bloom, key_t item)
+cdef void bloom_add(BloomStruct* bloom, key_t item) nogil
 
 cdef bint bloom_contains(BloomStruct* bloom, key_t item) nogil
 

--- a/preshed/bloom.pxd
+++ b/preshed/bloom.pxd
@@ -1,0 +1,24 @@
+from libc.stdint cimport uint32_t, uint64_t
+from cymem.cymem cimport Pool
+
+ctypedef uint64_t key_t
+
+cdef struct BloomStruct:
+    key_t* bitfield
+    key_t hcount # hash count, number of hash functions
+    key_t length
+
+
+cdef class BloomFilter:
+    cdef Pool mem
+    cdef BloomStruct* c_bloom
+
+    cdef inline bint contains(self, key_t item) nogil
+
+cdef void bloom_init(Pool mem, BloomStruct* bloom, key_t hcount, key_t length)
+
+cdef void bloom_add(BloomStruct* bloom, key_t item)
+
+cdef bint bloom_contains(BloomStruct* bloom, key_t item) nogil
+
+

--- a/preshed/bloom.pyx
+++ b/preshed/bloom.pyx
@@ -1,0 +1,61 @@
+# cython: infer_types=True
+# cython: cdivision=True
+#
+cimport cython
+
+from murmurhash.mrmr cimport hash64
+import math
+
+def optimal_params(members, error_rate):
+    """Calculate the optimal size in bits and number of hash functions for a
+    given number of members and error rate.  
+    """
+    base = math.log(1 / (2 ** math.log2))
+    bit_count = math.ceil((members * math.log(error_rate)) / base)
+    hash_count = math.floor((bit_count / members) * math.log(2))
+    return dict(size=bit_count, hash_funcs=hash_count)
+
+cdef class BloomFilter:
+    """Bloom filter that allows for basic membership tests.
+    
+    Only integers are supported as keys.
+    """
+    def __init__(self, key_t size=(2 ** 10), key_t hash_funcs=23):
+        self.mem = Pool()
+
+        self.c_bloom = <BloomStruct*>self.mem.alloc(1, sizeof(BloomStruct))
+        bloom_init(self.mem, self.c_bloom, hash_funcs, size)
+
+    def add(self, key_t item):
+        bloom_add(self.c_bloom, item)
+
+    def __contains__(self, item):
+        return bloom_contains(self.c_bloom, item)
+
+    cdef inline bint contains(self, key_t item) nogil:
+        return bloom_contains(self.c_bloom, item)
+
+cdef void bloom_init(Pool mem, BloomStruct* bloom, key_t hcount, key_t length):
+    # size should be a multiple of the container size - round up
+    if length % sizeof(key_t):
+        length = math.ceil(length / sizeof(key_t)) * sizeof(key_t)
+    bloom.length = length
+    bloom.hcount = hcount
+    bloom.bitfield = <key_t*>mem.alloc(length // sizeof(key_t), sizeof(key_t))
+
+cdef void bloom_add(BloomStruct* bloom, key_t item):
+    cdef key_t hv
+    for seed in range(bloom.hcount):
+        hv = hash64(&item, sizeof(key_t), seed) % bloom.length
+        bloom.bitfield[hv // sizeof(key_t)] |= 1 << (hv % sizeof(key_t))
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef bint bloom_contains(BloomStruct* bloom, key_t item) nogil:
+    cdef key_t hv
+    for seed in range(bloom.hcount):
+        hv = hash64(&item, sizeof(key_t), seed) % bloom.length
+        if not (bloom.bitfield[hv // sizeof(key_t)] & 
+           1 << (hv % sizeof(key_t))):
+            return False
+    return True

--- a/preshed/bloom.pyx
+++ b/preshed/bloom.pyx
@@ -13,7 +13,7 @@ def calculate_size_and_hash_count(members, error_rate):
     base = math.log(1 / (2 ** math.log(2)))
     bit_count = math.ceil((members * math.log(error_rate)) / base)
     hash_count = math.floor((bit_count / members) * math.log(2))
-    return dict(size=bit_count, hash_funcs=hash_count)
+    return (bit_count, hash_count)
 
 cdef class BloomFilter:
     """Bloom filter that allows for basic membership tests.
@@ -25,6 +25,11 @@ cdef class BloomFilter:
 
         self.c_bloom = <BloomStruct*>self.mem.alloc(1, sizeof(BloomStruct))
         bloom_init(self.mem, self.c_bloom, hash_funcs, size)
+
+    @classmethod
+    def from_error_rate(cls, members, error_rate=1E-4):
+        params = calculate_size_and_hash_count(members, error_rate)
+        return cls(*params)
 
     def add(self, key_t item):
         bloom_add(self.c_bloom, item)

--- a/preshed/tests/test_bloom.py
+++ b/preshed/tests/test_bloom.py
@@ -1,0 +1,26 @@
+from __future__ import division
+import pytest
+
+from preshed.bloom import BloomFilter
+
+def test_contains():
+    bf = BloomFilter()
+    assert 23 not in bf
+    bf.add(23)
+    assert 23 in bf
+
+    bf.add(5)
+    bf.add(42)
+    bf.add(1002)
+    assert 5 in bf
+    assert 42 in bf
+    assert 1002 in bf
+
+def test_no_false_negatives():
+    bf = BloomFilter(size=100, hash_funcs=2)
+    for ii in range(0,1000,20):
+        bf.add(ii)
+
+    for ii in range(0,1000,20):
+        assert ii in bf
+

--- a/preshed/tests/test_bloom.py
+++ b/preshed/tests/test_bloom.py
@@ -24,3 +24,12 @@ def test_no_false_negatives():
     for ii in range(0,1000,20):
         assert ii in bf
 
+def test_from_error():
+    bf = BloomFilter.from_error_rate(1000)
+    for ii in range(0,1000,20):
+        bf.add(ii)
+
+    for ii in range(0,1000,20):
+        assert ii in bf
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cymem>=2.0.2,<2.1.0
 cython>=0.28
 pytest
+murmurhash==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 PACKAGES = ["preshed", "preshed.tests"]
-MOD_NAMES = ["preshed.maps", "preshed.counter"]
+MOD_NAMES = ["preshed.maps", "preshed.counter", "preshed.bloom"]
 
 
 # By subclassing build_extensions we have the actual compiler that will be used which is really known only after finalize_options


### PR DESCRIPTION
This adds bloom filters and tests. The bloom filter only accepts integer
keys, though it would be easy to extend it.

The bloom filter uses MurmurHash, so that's been added as a dependency.

This is added as part of work towards the proposal explosion/spacy#3971.