### PR TITLE
bloom: replace raw array with `std::vector` and raw pointer with `std::unique_ptr`

### DIFF
--- a/preshed/bloom.pxd
+++ b/preshed/bloom.pxd
@@ -1,10 +1,11 @@
 from libc.stdint cimport uint64_t, uint32_t
+from libcpp.vector cimport vector
 from cymem.cymem cimport Pool
 
 ctypedef uint64_t key_t
 
 cdef struct BloomStruct:
-    key_t* bitfield
+    vector[key_t] bitfield
     key_t hcount # hash count, number of hash functions
     key_t length
     uint32_t seed
@@ -16,7 +17,7 @@ cdef class BloomFilter:
     cdef inline bint contains(self, key_t item) nogil
 
 
-cdef void bloom_init(Pool mem, BloomStruct* bloom, key_t hcount, key_t length, uint32_t seed) except *
+cdef void bloom_init(BloomStruct* bloom, key_t hcount, key_t length, uint32_t seed) except *
 
 cdef void bloom_add(BloomStruct* bloom, key_t item) nogil
 

--- a/preshed/bloom.pxd
+++ b/preshed/bloom.pxd
@@ -1,10 +1,10 @@
 from libc.stdint cimport uint64_t, uint32_t
+from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.vector cimport vector
-from cymem.cymem cimport Pool
 
 ctypedef uint64_t key_t
 
-cdef struct BloomStruct:
+cdef cppclass BloomStruct:
     vector[key_t] bitfield
     key_t hcount # hash count, number of hash functions
     key_t length
@@ -12,8 +12,7 @@ cdef struct BloomStruct:
 
 
 cdef class BloomFilter:
-    cdef Pool mem
-    cdef BloomStruct* c_bloom
+    cdef unique_ptr[BloomStruct] c_bloom
     cdef inline bint contains(self, key_t item) nogil
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ MOD_NAMES = ["preshed.maps", "preshed.counter", "preshed.bloom"]
 # By subclassing build_extensions we have the actual compiler that will be used which is really known only after finalize_options
 # http://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used
 compile_options = {
-    "msvc": ["/Ox", "/EHsc"],
-    "other": ["-O3", "-Wno-strict-prototypes", "-Wno-unused-function"],
+    "msvc": ["/Ox", "/EHsc", "/std:c++14"],
+    "other": ["-O3", "-Wno-strict-prototypes", "-Wno-unused-function", "-std=c++14"],
 }
 link_options = {"msvc": [], "other": []}
 


### PR DESCRIPTION
We could make similar changes to the other modules, but I wanted to avoid making an excessively large PR.